### PR TITLE
allow customization of welcome email per-experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A frontend for Keycloak user manangement for WIPAC/IceCube.
   + [Approval Actions](#approval-actions)
 * [REST API](#rest-api)
 * [Web App](#web-app)
+* [Env Variables](#env-variables)
 * [Running Tests](#running-tests)
   + [Getting Test Coverage](#getting-test-coverage)
 
@@ -65,6 +66,21 @@ Primary access to the user-facing service is via a web application.
 This is purely browser-based (JavaScript), and connects to the
 [REST API](#rest-api) for actions. Authentication comes from connecting
 to a Keycloak client specifically created for this and the REST API.
+
+## Env Variables
+
+Several things can be customized. Here is a selection of env variables that can be set:
+
+### Emails to users:
+
+* `<exp>_WELCOME_SUBJECT`
+* `<exp>_WELCOME_CONTENT`
+* `<exp>_CHANGE_SUBJECT`
+* `<exp>_CHANGE_CONTENT`
+* `<exp>_DENY_SUBJECT`
+* `<exp>_DENY_CONTENT`
+
+These also take format strings for select variables, like `first_name`, `username`, `password`.
 
 ## Running Tests
 

--- a/tests/test_api_insts.py
+++ b/tests/test_api_insts.py
@@ -700,7 +700,7 @@ async def test_inst_approvals_email_customization(exp, server, mongo_client, reg
 
     client = await reg_token_client()
     data = {
-        'experiment': 'IceCube',
+        'experiment': exp,
         'institution': 'UW-Madison',
         'first_name': 'First',
         'last_name': 'Last',
@@ -725,6 +725,6 @@ async def test_inst_approvals_email_customization(exp, server, mongo_client, reg
 
     email_patch.assert_called()
     logging.info('call_args: %r', email_patch.call_args)
-    assert email_patch.call_args.kwargs['subject'] == 'Welcome test test'
-    assert email_patch.call_args.kwargs['body'].startswith(f'Welcome to {exp}/UW-Madison. Your username is test and password is')
+    assert email_patch.call_args.kwargs['subject'] == 'Welcome First Last'
+    assert email_patch.call_args.kwargs['body'].startswith(f'Welcome to {exp}/UW-Madison. Your username is flast and password is')
 

--- a/tests/test_api_insts.py
+++ b/tests/test_api_insts.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 from rest_tools.client import AsyncSession
@@ -676,3 +677,42 @@ async def test_inst_approvals_actions_deny(server, mongo_client, email_patch):
 
     ret = await krs.groups.get_group_membership('/institutions/IceCube/UW-Madison', rest_client=krs_client)
     assert 'test' not in ret
+
+
+@pytest.mark.parametrize('exp', ['IceCube', 'CTA'])
+@pytest.mark.asyncio
+async def test_inst_approvals_email_customization(exp, server, mongo_client, email_patch, monkeypatch):
+    rest, krs_client, *_ = server
+
+    await krs.groups.create_group('/institutions', rest_client=krs_client)
+    await krs.groups.create_group(f'/institutions/{exp}', rest_client=krs_client)
+    await krs.groups.create_group(f'/institutions/{exp}/UW-Madison', rest_client=krs_client)
+
+    client = await rest('test')
+    client2 = await rest('test2', groups=[f'/institutions/{exp}/UW-Madison/_admin'])
+
+    data = {
+        'experiment': exp,
+        'institution': 'UW-Madison',
+    }
+    ret = await client.request('POST', '/api/inst_approvals', data)
+    approval_id = ret['id']
+
+    email_patch.assert_called()
+    email_patch.reset_mock()
+
+    # specify email customization
+    monkeypatch.setenv(f'{exp}_WELCOME_SUBJECT', 'Welcome {first_name} {last_name}')
+    monkeypatch.setenv(f'{exp}_WELCOME_CONTENT', 'Welcome to {experiment}/{institution}. Your username is {username} and password is {password}.')
+
+    # approve
+    await client2.request('POST', f'/api/inst_approvals/{approval_id}/actions/approve')
+
+    ret = await mongo_client.inst_approvals.find().to_list(10)
+    assert len(ret) == 0
+
+    email_patch.assert_called()
+    logging.info('call_args: %r', email_patch.call_args)
+    assert email_patch.call_args.kwargs['subject'] == 'Welcome test test'
+    assert email_patch.call_args.kwargs['body'].startswith(f'Welcome to {exp}/UW-Madison. Your username is test and password is')
+

--- a/tests/test_api_insts.py
+++ b/tests/test_api_insts.py
@@ -1,15 +1,14 @@
 import asyncio
 import logging
 
+import krs.email
+import krs.groups
+import krs.users
 import pytest
 from rest_tools.client import AsyncSession
 
-import krs.users
-import krs.groups
-import krs.email
-
 from .krs_util import keycloak_bootstrap
-from .util import port, server, mongo_client, reg_token_client, email_patch
+from .util import email_patch, mongo_client, port, reg_token_client, server
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_insts.py
+++ b/tests/test_api_insts.py
@@ -726,5 +726,5 @@ async def test_inst_approvals_email_customization(exp, server, mongo_client, reg
     email_patch.assert_called()
     logging.info('call_args: %r', email_patch.call_args)
     assert email_patch.call_args.kwargs['subject'] == 'Welcome First Last'
-    assert email_patch.call_args.kwargs['body'].startswith(f'Welcome to {exp}/UW-Madison. Your username is flast and password is')
+    assert email_patch.call_args.kwargs['content'].startswith(f'Welcome to {exp}/UW-Madison. Your username is flast and password is')
 

--- a/tests/test_api_insts.py
+++ b/tests/test_api_insts.py
@@ -681,24 +681,36 @@ async def test_inst_approvals_actions_deny(server, mongo_client, email_patch):
 
 @pytest.mark.parametrize('exp', ['IceCube', 'CTA'])
 @pytest.mark.asyncio
-async def test_inst_approvals_email_customization(exp, server, mongo_client, email_patch, monkeypatch):
+async def test_inst_approvals_email_customization(exp, server, mongo_client, reg_token_client, email_patch, monkeypatch):
     rest, krs_client, *_ = server
 
     await krs.groups.create_group('/institutions', rest_client=krs_client)
     await krs.groups.create_group(f'/institutions/{exp}', rest_client=krs_client)
     await krs.groups.create_group(f'/institutions/{exp}/UW-Madison', rest_client=krs_client)
 
-    client = await rest('test')
+    #client = await rest('test')
     client2 = await rest('test2', groups=[f'/institutions/{exp}/UW-Madison/_admin'])
 
+    #data = {
+    #    'experiment': exp,
+    #    'institution': 'UW-Madison',
+    #}
+    #ret = await client.request('POST', '/api/inst_approvals', data)
+    #approval_id = ret['id']
+
+    client = await reg_token_client()
     data = {
-        'experiment': exp,
+        'experiment': 'IceCube',
         'institution': 'UW-Madison',
+        'first_name': 'First',
+        'last_name': 'Last',
+        'username': 'flast',
+        'email': 'test@test',
+        'supervisor': 'test2',
     }
     ret = await client.request('POST', '/api/inst_approvals', data)
     approval_id = ret['id']
 
-    email_patch.assert_called()
     email_patch.reset_mock()
 
     # specify email customization

--- a/tests/test_api_insts.py
+++ b/tests/test_api_insts.py
@@ -683,6 +683,7 @@ async def test_inst_approvals_actions_deny(server, mongo_client, email_patch):
 async def test_inst_approvals_email_customization(exp, server, mongo_client, reg_token_client, email_patch, monkeypatch):
     rest, krs_client, *_ = server
 
+    await krs.groups.create_group('/posix', rest_client=krs_client)
     await krs.groups.create_group('/institutions', rest_client=krs_client)
     await krs.groups.create_group(f'/institutions/{exp}', rest_client=krs_client)
     await krs.groups.create_group(f'/institutions/{exp}/UW-Madison', rest_client=krs_client)

--- a/user_mgmt/insts.py
+++ b/user_mgmt/insts.py
@@ -524,12 +524,6 @@ E-mail Address:  {username}@icecube.wisc.edu
 Please change your password immediately. Go to the password reset page to do so:
   https://keycloak.icecube.wisc.edu/auth/realms/IceCube/account/
 
-Many IceCube resources, including the IceCube wiki, are protected with a
-generic set of user credentials. If you see a window asking for security
-credentials, enter the generic IceCube credentials below.
-  Username:  icecube
-  Password:  skua
-
 More information about your account and resources available to you can be
 found in the wiki:
   https://wiki.icecube.wisc.edu/index.php/Newbies

--- a/user_mgmt/insts.py
+++ b/user_mgmt/insts.py
@@ -563,13 +563,13 @@ You are now a member of {experiment}/{institution}.
             if newuser:
                 krs.email.send_email(
                     recipient={'name': f'{args["first_name"]} {args["last_name"]}', 'email': args['email']},
-                    subject=config[f'{exp}_WELCOME_SUBJECT'],
+                    subject=str(config[f'{exp}_WELCOME_SUBJECT']).format_map(email_args),
                     content=str(config[f'{exp}_WELCOME_CONTENT']).format_map(email_args)
                 )
             else:
                 krs.email.send_email(
                     recipient={'name': f'{args["firstName"]} {args["lastName"]}', 'email': args['email']},
-                    subject=config[f'{exp}_CHANGE_SUBJECT'],
+                    subject=str(config[f'{exp}_CHANGE_SUBJECT']).format_map(email_args),
                     content=str(config[f'{exp}_CHANGE_CONTENT']).format_map(email_args)
                 )
         except Exception:
@@ -632,7 +632,7 @@ Your account request for {experiment}/{institution} is denied.
             email_args = SafeDict(**args)
             krs.email.send_email(
                 recipient={'name': f'{args["firstName"]} {args["lastName"]}', 'email': args['email']},
-                subject=f'{exp}_DENY_SUBJECT',
+                subject=str(config[f'{exp}_DENY_SUBJECT']).format_map(email_args),
                 content=str(config[f'{exp}_DENY_CONTENT']).format_map(email_args)
             )
         except Exception:

--- a/user_mgmt/insts.py
+++ b/user_mgmt/insts.py
@@ -11,6 +11,7 @@ import krs.groups
 import krs.users
 from rest_tools.server import authenticated, catch_error
 from tornado.web import HTTPError
+from wipac_dev_tools import from_environment
 
 from .handler import MyHandler
 from .users import Username
@@ -37,6 +38,12 @@ def gen_password(len: int = 16) -> str:
                 and sum(c.isdigit() for c in password) >= 3):
             break
     return password
+
+
+class SafeDict(dict):
+    # This method is called whenever a key is missing
+    def __missing__(self, key):
+        return f"{{{key}}}"  # Returns the key name in braces if missing
 
 
 class Experiments(MyHandler):
@@ -442,22 +449,30 @@ class InstApprovalsActionApprove(MyHandler):
             if not user_data:
                 raise HTTPError(400, reason='invalid new user')
             args = {
-                "username": user_data['username'],
-                "first_name": user_data['first_name'],
-                "last_name": user_data['last_name'],
-                "email": user_data['external_email'],
-                "attribs": {},
+                'username': user_data['username'],
+                'first_name': user_data['first_name'],
+                'last_name': user_data['last_name'],
+                'email': user_data['external_email'],
+                'attribs': {},
             }
             if user_data.get('author_name', ''):
                 args['attribs']['author_name'] = user_data['author_name']
             await krs.users.create_user(rest_client=self.krs_client, **args)
             password = gen_password(16)
             await krs.users.set_user_password(args['username'], password, temporary=True, rest_client=self.krs_client)
+            args['password'] = password
 
             # posix by default
             await krs.groups.add_user_group('/posix', args['username'], rest_client=self.krs_client)
 
             await self.db.user_registrations.delete_one({'id': ret['newuser']})
+        
+        else:
+            # get existing user
+            try:
+                args = await self.user_cache.get_user(ret['username'])
+            except Exception:
+                raise HTTPError(400, reason='invalid username')
 
         # add user to institution
         inst_group = f'/institutions/{ret["experiment"]}/{ret["institution"]}'
@@ -495,17 +510,16 @@ class InstApprovalsActionApprove(MyHandler):
 
         # send email
         try:
-            if newuser:
-                krs.email.send_email(
-                    recipient={'name': f'{args["first_name"]} {args["last_name"]}', 'email': args['email']},
-                    subject='IceCube Account Approved',
-                    content=f'''Welcome to IceCube {args["first_name"]} {args["last_name"]}!
+            exp = ret['experiment']
+            default_config = {
+                f'{exp}_WELCOME_SUBJECT': 'IceCube Account Approved',
+                f'{exp}_WELCOME_CONTENT': '''Welcome to IceCube {first_name} {last_name}!
 
 You have a new account with the IceCube project at UW-Madison.
 
-Username:  {args["username"]}
+Username:  {username}
 Password:  {password}
-E-mail Address:  {args["username"]}@icecube.wisc.edu
+E-mail Address:  {username}@icecube.wisc.edu
 
 Please change your password immediately. Go to the password reset page to do so:
   https://keycloak.icecube.wisc.edu/auth/realms/IceCube/account/
@@ -532,20 +546,32 @@ By using this account, you agree to the IceCube IT Acceptable Use Policy.
 
 IceCube accounts are also subject to University of Wisconsin-Madison policies
 listed in the "Other Governing Agreements" section of the policy linked above.
-''')
-            else:
-                try:
-                    args = await self.user_cache.get_user(ret['username'])
-                except Exception:
-                    raise HTTPError(400, reason='invalid username')
-                krs.email.send_email(
-                    recipient={'name': f'{args["firstName"]} {args["lastName"]}', 'email': args['email']},
-                    subject='IceCube Account Institution Changes',
-                    content=f'''IceCube Institution Change
+''',
+                f'{exp}_CHANGE_SUBJECT': 'IceCube Account Institution Changes',
+                f'{exp}_CHANGE_CONTENT': '''IceCube Institution Change
 
 Your account with the IceCube project at UW-Madison has been altered.
-You are now a member of {ret["experiment"]}/{ret["institution"]}.
-''')
+You are now a member of {experiment}/{institution}.
+''',
+            }
+            config = from_environment(default_config)
+
+            email_args = SafeDict(**args)
+            email_args['experiment'] = exp
+            email_args['institution'] = ret['institution']
+
+            if newuser:
+                krs.email.send_email(
+                    recipient={'name': f'{args["first_name"]} {args["last_name"]}', 'email': args['email']},
+                    subject=config[f'{exp}_WELCOME_SUBJECT'],
+                    content=str(config[f'{exp}_WELCOME_CONTENT']).format_map(email_args)
+                )
+            else:
+                krs.email.send_email(
+                    recipient={'name': f'{args["firstName"]} {args["lastName"]}', 'email': args['email']},
+                    subject=config[f'{exp}_CHANGE_SUBJECT'],
+                    content=str(config[f'{exp}_CHANGE_CONTENT']).format_map(email_args)
+                )
         except Exception:
             logging.warning('failed to send email for inst approval', exc_info=True)
 
@@ -578,29 +604,37 @@ class InstApprovalsActionDeny(MyHandler):
             if not user_data:
                 raise HTTPError(400, reason='invalid new user')
             await self.db.user_registrations.delete_one({'id': ret['newuser']})
+            args = {
+                "username": user_data['username'],
+                "firstName": user_data['first_name'],
+                "lastName": user_data['last_name'],
+                "email": user_data['external_email'],
+            }
+        else:
+            try:
+                args = await self.user_cache.get_user(ret['username'])
+            except Exception:
+                raise HTTPError(400, reason='invalid username')
         await self.db.inst_approvals.delete_one({'id': approval_id})
 
         # send email
         try:
-            if newuser:
-                args = {
-                    "username": user_data['username'],
-                    "firstName": user_data['first_name'],
-                    "lastName": user_data['last_name'],
-                    "email": user_data['external_email'],
-                }
-            else:
-                try:
-                    args = await self.user_cache.get_user(ret['username'])
-                except Exception:
-                    raise HTTPError(400, reason='invalid username')
+            exp = ret['experiment']
+            default_config = {
+                f'{exp}_DENY_SUBJECT': 'IceCube Account Request Denied',
+                f'{exp}_DENY_CONTENT': '''IceCube Account Request Denied
+
+Your account request for {experiment}/{institution} is denied.
+'''
+            }
+            config = from_environment(default_config)
+
+            email_args = SafeDict(**args)
             krs.email.send_email(
                 recipient={'name': f'{args["firstName"]} {args["lastName"]}', 'email': args['email']},
-                subject='IceCube Account Request Denied',
-                content=f'''IceCube Account Request Denied
-
-Your account request for {ret["experiment"]}/{ret["institution"]} is denied.
-''')
+                subject=f'{exp}_DENY_SUBJECT',
+                content=str(config[f'{exp}_DENY_CONTENT']).format_map(email_args)
+            )
         except Exception:
             logging.warning('failed to send email for inst deny', exc_info=True)
 


### PR DESCRIPTION
Closes #1 (finally!).

### Email variables:

* `<exp>_WELCOME_SUBJECT`
* `<exp>_WELCOME_CONTENT`
* `<exp>_CHANGE_SUBJECT`
* `<exp>_CHANGE_CONTENT`
* `<exp>_DENY_SUBJECT`
* `<exp>_DENY_CONTENT`

These also take format strings for select variables, like `first_name`, `username`, `password`.

An example is setting CTA_WELCOME_CONTENT to 
```
Welcome to {experiment}/{institution}. Your username is {username} and password is {password}.
```


Note that this will allow us to remove the icecube generic password from github.